### PR TITLE
add searchbox hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = (options) => ({
     return {
       name: "select-hooks.js",
       content: `export default {
-        onPageChange: ${hooks.onPageChange || nullHook}
+        onSelectSearchBox: ${hooks.onSelectSearchBox || nullHook}
       }`
     };
   },

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = (options) => ({
     return {
       name: "select-hooks.js",
       content: `export default {
-        onSelectSearchBox: ${hooks.onSelectSearchBox || nullHook}
+        beforeNavToSelectedSuggestion: ${hooks.beforeNavToSelectedSuggestion || nullHook}
       }`
     };
   },

--- a/index.js
+++ b/index.js
@@ -23,6 +23,16 @@ module.exports = (options) => ({
   alias: {
     "@SearchBox": path.resolve(__dirname, "src", "SearchBox.vue"),
   },
+  clientDynamicModules: () => {
+    const hooks = options.hooks || { }
+    const nullHook = () => {}
+    return {
+      name: "select-hooks.js",
+      content: `export default {
+        onPageChange: ${hooks.onPageChange || nullHook}
+      }`
+    };
+  },
   define: {
     SEARCH_OPTIONS: options.search_options || defaultSearchOptions,
     SEARCH_MAX_SUGGESTIONS: options.maxSuggestions || 10,

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ module.exports = (options) => ({
   alias: {
     "@SearchBox": path.resolve(__dirname, "src", "SearchBox.vue"),
   },
+  // implementation based on https://github.com/z3by/vuepress-plugin-flexsearch/pull/37
   clientDynamicModules: () => {
     const hooks = options.hooks || { }
     const nullHook = () => {}

--- a/src/SearchBox.vue
+++ b/src/SearchBox.vue
@@ -49,6 +49,7 @@
 import VuepressSearchBox from "@vuepress/plugin-search/SearchBox.vue";
 import Flexsearch from "flexsearch";
 import { highlightText } from "./utils";
+import hooks from '@dynamic/select-hooks';
 
 /* global
 SEARCH_MAX_SUGGESTIONS
@@ -105,6 +106,7 @@ export default {
       const path = this.suggestions[i].path
 
       if (this.$route.path !== path) {
+        hooks.onPageChange(this.query, this.$route.path, path);
         this.$router.push(this.suggestions[i].path)
       }
 

--- a/src/SearchBox.vue
+++ b/src/SearchBox.vue
@@ -106,7 +106,7 @@ export default {
       const path = this.suggestions[i].path
 
       if (this.$route.path !== path) {
-        hooks.onSelectSearchBox(this.query, this.$route.path, path);
+        hooks.beforeNavToSelectedSuggestion(this.query, this.$route.path, path);
         this.$router.push(this.suggestions[i].path)
       }
 

--- a/src/SearchBox.vue
+++ b/src/SearchBox.vue
@@ -106,7 +106,7 @@ export default {
       const path = this.suggestions[i].path
 
       if (this.$route.path !== path) {
-        hooks.onPageChange(this.query, this.$route.path, path);
+        hooks.onSelectSearchBox(this.query, this.$route.path, path);
         this.$router.push(this.suggestions[i].path)
       }
 


### PR DESCRIPTION
- Added beforeNavToSelectedSuggestion hook which fires on router path change.
- Function is passed into plugin as an argument. If no function is passed, generic blank function is set.
- Function currently gets args from the plugin itself (search query, current path and next path). Sufficient for now but could be made more generic by not relying on these args.