### PR TITLE
fix: url tracked on posthog searchbox event

### DIFF
--- a/src/SearchBox.vue
+++ b/src/SearchBox.vue
@@ -110,7 +110,7 @@ export default {
 
         // Include domain in route paths
         if (typeof window !== 'undefined'){
-          let domain = window.location.href
+          let domain = window.location.origin
           if (domain.endsWith('/')){
             domain = domain.slice(0, -1)
           }


### PR DESCRIPTION
The base URL was being set incorrectly causing duplication in some of the URLs tracked for Page.Search events sent to posthog, e.g:

![image](https://github.com/arup-group/vuepress-plugin-flexsearch/assets/77862637/c08120a8-eca1-4a6f-b99e-904a0f5b9227)

Behaviour with changes from this PR:

![image](https://github.com/arup-group/vuepress-plugin-flexsearch/assets/77862637/19e19917-49c0-45ab-8c05-1ad9680eccde)
